### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/policy/monocamMapper.paf
+++ b/policy/monocamMapper.paf
@@ -475,4 +475,7 @@ datasets: {
         tables: raw
         tables: raw_visit
     }
+    apPipe_metadata: {
+        template:      "apPipe_metadata/v%(visit)d_f%(filter)s.boost"
+    }
 }


### PR DESCRIPTION
This PR registers dataset mappings for configs and metadata persisted by `ApPipeTask`.