### PR TITLE
DM-6640: IsrTask is not a valid CmdLineTask

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -1,0 +1,8 @@
+"""
+Monocam-specific overrides for IsrTask
+"""
+config.doDark = True
+config.doBias = True
+config.doFlat = True
+config.doFringe = False
+config.doLinearize = False

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -1,14 +1,18 @@
+"""
+Monocam-specific overrides for ProcessCcdTask
+"""
+import os.path
+
+from lsst.utils import getPackageDir
 from lsst.obs.monocam import MonocamIsrTask
+
+obsConfigDir = os.path.join(getPackageDir("obs_monocam"), "config")
+
 config.isr.retarget(MonocamIsrTask)
-config.isr.doDark = True
-config.isr.doBias = True
-config.isr.doFlat = True
-config.isr.doFringe = False
-config.isr.doLinearize = False
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))
 
 config.charImage.repair.doCosmicRay = False
 config.charImage.repair.cosmicray.nCrPixelMax = 1000000
-
 
 config.charImage.background.binSize = 128
 config.charImage.detectAndMeasure.detection.background.binSize = 128

--- a/config/runIsr.py
+++ b/config/runIsr.py
@@ -1,0 +1,12 @@
+"""
+Monocam-specific overrides for RunIsrTask
+"""
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.monocam.monocamIsrTask import MonocamIsrTask
+
+obsConfigDir = os.path.join(getPackageDir("obs_monocam"), "config")
+
+config.isr.retarget(MonocamIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))


### PR DESCRIPTION
This ticket adds a stand-alone runIsr.py script, as well as ensuring that runIsr.py and processCcd.py read the same ISR configuration files.
