### PR TITLE
tickets/DM-9334 Remove vestigial monocamIngestImages.py script

### DIFF
--- a/bin.src/monocamIngestImages.py
+++ b/bin.src/monocamIngestImages.py
@@ -1,3 +1,0 @@
-#!/usr/bin/env python
-from lsst.obs.monocam.ingest import MonocamIngestTask
-MonocamIngestTask.parseAndRun()


### PR DESCRIPTION
MonocamIngestTask was previously removed, therefore
monocamIngestImages.py is a confusing remnant.